### PR TITLE
Update CI pipeline for terraform-docs version 1.8.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
 
       # Validate Terraform documentation with terraform-docs
       - name: Terraform Docs
-        uses: terraform-docs/gh-actions@v1.1.0
+        uses: terraform-docs/gh-actions@v1.2.2
         with:
           config-file: ${{ env.TERRAFORM_DOCS_CONFIG_FILE_PATH }}
           git-commit-message: 'docs: terraform-docs automated update'

--- a/key-vault.tf
+++ b/key-vault.tf
@@ -1,4 +1,5 @@
 resource "azurerm_key_vault" "main" {
+  #checkov:skip=CKV2_AZURE_32: [TODO] Support private endpoints
   name                = local.resource_name.key_vault
   location            = var.location
   resource_group_name = var.resource_group_name


### PR DESCRIPTION
- Update terrform-docs GitHub Action version to 1.2.2 to support terraform-docs version 1.8.0.